### PR TITLE
transform points to objects before benchmark

### DIFF
--- a/bench/bench.js
+++ b/bench/bench.js
@@ -38,11 +38,11 @@ const options = {
 }
 
 const hole_hole = load.sync('./bench/fixtures/hole_hole.geojson')
+const hole_hole_obj_0 = mfogel.toObjects(hole_hole.features[0].geometry.coordinates)
+const hole_hole_obj_1 = mfogel.toObjects(hole_hole.features[1].geometry.coordinates)
 new Benchmark.Suite('Hole_Hole', options)
   .add('mfogel', () => {
-    mfogel.union(
-      hole_hole.features[0].geometry.coordinates,
-      hole_hole.features[1].geometry.coordinates)
+    mfogel.union(hole_hole_obj_0, hole_hole_obj_1)
   })
   .add('w8r', () => {
     w8r.union(
@@ -56,11 +56,11 @@ new Benchmark.Suite('Hole_Hole', options)
 
 const asia = load.sync('./bench/fixtures/asia.geojson')
 const unionPoly = load.sync('./bench/fixtures/asia_unionPoly.geojson')
+const asia_obj = mfogel.toObjects(asia.features[0].geometry.coordinates)
+const union_obj = mfogel.toObjects(unionPoly.geometry.coordinates)
 new Benchmark.Suite('Asia union', options)
   .add('mfogel', () => {
-    mfogel.union(
-      asia.features[0].geometry.coordinates,
-      unionPoly.geometry.coordinates)
+    mfogel.union(asia_obj, union_obj)
   })
   .add('w8r', () => {
     w8r.union(
@@ -71,11 +71,11 @@ new Benchmark.Suite('Asia union', options)
   .run()
 
 const states = load.sync('./bench/fixtures/states_source.geojson')
+const states_obj_0 = mfogel.toObjects(states.features[0].geometry.coordinates)
+const states_obj_1 = mfogel.toObjects(states.features[1].geometry.coordinates)
 new Benchmark.Suite('States clip', options)
   .add('mfogel', () => {
-    mfogel.union(
-      states.features[0].geometry.coordinates,
-      states.features[1].geometry.coordinates)
+    mfogel.union(states_obj_0, states_obj_1)
   })
   .add('w8r', () => {
     w8r.union(

--- a/main.js
+++ b/main.js
@@ -1,5 +1,6 @@
 const doIt = require('./src')
 const operation = require('./src/operation')
+const clean = require('./src/clean-input')
 
 const union = (geom, ...moreGeoms) => {
   return doIt(operation.types.UNION, geom, moreGeoms)
@@ -17,4 +18,8 @@ const difference = (subjectGeom, ...clippingGeoms) => {
   return doIt(operation.types.DIFFERENCE, subjectGeom, clippingGeoms)
 }
 
-module.exports = { union, intersection, xor, difference }
+const toObjects = (geom) => {
+	return clean.pointsAsObjects(geom)
+}
+
+module.exports = { union, intersection, xor, difference, toObjects }

--- a/src/index.js
+++ b/src/index.js
@@ -6,11 +6,11 @@ const operation = require('./operation')
 const SweepEvent = require('./sweep-event')
 const SweepLine = require('./sweep-line')
 
-const doIt = (operationType, geom, moreGeoms) => {
+const doIt = (operationType, geom, moreGeoms, toObjects=false) => {
   /* Make a copy of the input geometry with points as objects, for perf */
-  const geoms = [cleanInput.pointsAsObjects(geom)]
+  const geoms = [toObjects ? cleanInput.pointsAsObjects(geom) : geom]
   for (let i = 0, iMax = moreGeoms.length; i < iMax; i++) {
-    geoms.push(cleanInput.pointsAsObjects(moreGeoms[i]))
+    geoms.push(toObjects ? cleanInput.pointsAsObjects(moreGeoms[i]) : moreGeoms[i])
   }
 
   /* Clean inputs */


### PR DESCRIPTION
Hey, not sure you want to add this but i tried to transform the array points to objects before the benchmark to see if this would speed up things - but it was not much change. Also added a `toObjects` to the main API and made an optional `toObjects` argument to the API calls.