### PR TITLE
Update splaytree dependency for treeshaking

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7628,9 +7628,9 @@
       "dev": true
     },
     "splaytree": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/splaytree/-/splaytree-2.0.3.tgz",
-      "integrity": "sha512-IziTvWQv9F1EiKq9XveosQRGTLrdUW0jLokpmAXz0+hnLgBZitvU0j4gUvCGASKwUQvCZaofhff1H8OmE2LRdA=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/splaytree/-/splaytree-3.0.0.tgz",
+      "integrity": "sha512-/FXCGITlLdmudFnMGSql9FO4P8Xfq3FgxUqiFlJtoQ7/nXqTqKn79xfhGuN+Yt/1kEFmcRUvv9yVjHAOOmqKWA=="
     },
     "split-string": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -69,6 +69,6 @@
     "vue-template-compiler": "^2.5.22"
   },
   "dependencies": {
-    "splaytree": "^2.0.3"
+    "splaytree": "^3.0.0"
   }
 }


### PR DESCRIPTION
As per #72 this updates the splaytree dependency so that this lib is able to be treeshaken.