### PR TITLE
Catch infinite loop when passing sweep line over endpoints (#95)

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,12 @@ The tests are broken up into unit tests and end-to-end tests. The end-to-end tes
 
 The Martinez-Rueda-Feito polygon clipping algorithm is used to compute the result in `O((n+k)*log(n))` time, where `n` is the total number of edges in all polygons involved and `k` is the number of intersections between edges.
 
+## Settings
+
+Global settings are set via environment variables.
+
+* **POLYGON_CLIPPING_MAX_QUEUE_SIZE** and **POLYGON_CLIPPING_MAX_SWEEPLINE_SEGMENTS**: Aims to prevent infinite loops - usually caused by floating-point math round-off errors. Defaults are 1,000,000.
+
 ## Changelog
 
 This project adheres to [Semantic Versioning](https://semver.org/).

--- a/src/operation.js
+++ b/src/operation.js
@@ -6,6 +6,10 @@ import rounder from './rounder'
 import SweepEvent from './sweep-event'
 import SweepLine from './sweep-line'
 
+// Limits on iterative processes to prevent infinite loops - usually caused by floating-point math round-off errors.
+const POLYGON_CLIPPING_MAX_QUEUE_SIZE = process.env.POLYGON_CLIPPING_MAX_QUEUE_SIZE || 1000000
+const POLYGON_CLIPPING_MAX_SWEEPLINE_SEGMENTS = process.env.POLYGON_CLIPPING_MAX_SWEEPLINE_SEGMENTS || 1000000
+
 export class Operation {
   run (type, geom, moreGeoms) {
     operation.type = type
@@ -52,6 +56,14 @@ export class Operation {
       const sweepEvents = multipolys[i].getSweepEvents()
       for (let j = 0, jMax = sweepEvents.length; j < jMax; j++) {
         queue.insert(sweepEvents[j])
+
+        if (queue.size > POLYGON_CLIPPING_MAX_QUEUE_SIZE) {
+          // prevents an infinite loop, an otherwise common manifestation of bugs
+          throw new Error(
+            'Infinite loop when putting segment endpoints in a priority queue ' +
+            '(queue size too big). Please file a bug report.'
+          )
+        }
       }
     }
 
@@ -73,7 +85,7 @@ export class Operation {
         )
       }
 
-      if (queue.size > 1000000) {
+      if (queue.size > POLYGON_CLIPPING_MAX_QUEUE_SIZE) {
         // prevents an infinite loop, an otherwise common manifestation of bugs
         throw new Error(
           'Infinite loop when passing sweep line over endpoints ' +
@@ -81,7 +93,7 @@ export class Operation {
         )
       }
 
-      if (sweepLine.segments.length > 1000000) {
+      if (sweepLine.segments.length > POLYGON_CLIPPING_MAX_SWEEPLINE_SEGMENTS) {
         // prevents an infinite loop, an otherwise common manifestation of bugs
         throw new Error(
           'Infinite loop when passing sweep line over endpoints ' +

--- a/src/operation.js
+++ b/src/operation.js
@@ -72,6 +72,23 @@ export class Operation {
           'Please file a bug report.'
         )
       }
+
+      if (queue.size > 1000000) {
+        // prevents an infinite loop, an otherwise common manifestation of bugs
+        throw new Error(
+          'Infinite loop when passing sweep line over endpoints ' +
+          '(queue size too big). Please file a bug report.'
+        )
+      }
+
+      if (sweepLine.segments.length > 1000000) {
+        // prevents an infinite loop, an otherwise common manifestation of bugs
+        throw new Error(
+          'Infinite loop when passing sweep line over endpoints ' +
+          '(too many sweep line segments). Please file a bug report.'
+        )
+      }
+
       const newEvents = sweepLine.process(evt)
       for (let i = 0, iMax = newEvents.length; i < iMax; i++) {
         const evt = newEvents[i]


### PR DESCRIPTION
This will at least allow gracefully dealing with the infinite looping, instead of chewing up heap space before ultimately crashing the entire process... Perhaps the limits could be 100,000 rather than 1,000,000 though?