### PR TITLE
Update splaytree dependency to get ES5 code

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15164,9 +15164,9 @@
       "dev": true
     },
     "splaytree": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/splaytree/-/splaytree-3.0.1.tgz",
-      "integrity": "sha512-WvQIHRDXLSVn72xjlIG/WGhv/4QO3m+iY2TpVdFRaXd1+/vkNlpkpw1QaNH5taghF9eWXDHWMWnzXyicR8d6ig=="
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/splaytree/-/splaytree-3.1.0.tgz",
+      "integrity": "sha512-gvUGR7xnOy0fLKTCxDeUZYgU/I1Tdf8M/lM1Qrf8L2TIOR5ipZjGk02uYcdv0o2x7WjVRgpm3iS2clLyuVAt0Q=="
     },
     "split-string": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -70,6 +70,6 @@
     "vue-template-compiler": "^2.6.12"
   },
   "dependencies": {
-    "splaytree": "^3.0.1"
+    "splaytree": "^3.1.0"
   }
 }


### PR DESCRIPTION
Just a quick version bump on splaytree. Looking to pick up [this fix](https://github.com/w8r/splay-tree/pull/16) so that we can have consistent ES5 code everywhere in [Turf](https://github.com/Turfjs/turf).