### PR TITLE
update to martinez-polygon-clipping 0.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "eslint-plugin-vue": "^7.2.0",
     "jest": "^26.6.3",
     "load-json-file": "^6.2.0",
-    "martinez-polygon-clipping": "0.5.0",
+    "martinez-polygon-clipping": "0.7.0",
     "npm-run-all": "^4.1.5",
     "rollup": "^2.35.1",
     "rollup-plugin-babel": "^4.4.0",


### PR DESCRIPTION
This PR updates to martinez-polygon-clipping 0.7.0 which has some key fixes for our work, notably this PR - https://github.com/w8r/martinez/pull/113.

I simply bumped the version, and all tests are still passing.  Let me know if anything further is needed.

Thanks.